### PR TITLE
fix(methodology): correct relative path so manifest reads succeed

### DIFF
--- a/site/methodology/clovis.qmd
+++ b/site/methodology/clovis.qmd
@@ -30,7 +30,7 @@ import json
 import pandas as pd
 from IPython.display import Markdown
 
-MANIFEST = Path("..") / "data" / "processed" / "clovis_MANIFEST.json"
+MANIFEST = Path("..") / ".." / "data" / "processed" / "clovis_MANIFEST.json"
 if MANIFEST.exists():
     with MANIFEST.open("r", encoding="utf-8") as f:
         m = json.load(f)

--- a/site/methodology/cpi.qmd
+++ b/site/methodology/cpi.qmd
@@ -43,7 +43,7 @@ import json
 import pandas as pd
 from IPython.display import Markdown
 
-MANIFEST = Path("..") / "data" / "processed" / "MANIFEST.json"
+MANIFEST = Path("..") / ".." / "data" / "processed" / "MANIFEST.json"
 if MANIFEST.exists():
     with MANIFEST.open("r", encoding="utf-8") as f:
         m = json.load(f)
@@ -74,7 +74,7 @@ from pathlib import Path
 import pandas as pd
 import plotly.graph_objects as go
 
-CPI_LATEST = Path("..") / "data" / "processed" / "cpi_latest.parquet"
+CPI_LATEST = Path("..") / ".." / "data" / "processed" / "cpi_latest.parquet"
 
 if CPI_LATEST.exists():
     cpi = pd.read_parquet(CPI_LATEST)


### PR DESCRIPTION
Three-line path fix on site/methodology/cpi.qmd and site/methodology/clovis.qmd.

Methodology pages live one directory deeper than top-level pages, so Path("..") resolved to site/ instead of the repo root. The freshness blocks were checking site/data/processed/ (nonexistent), MANIFEST.exists() returned False, and the rendered pages displayed the "Manifest not yet created" fallback despite the manifests being committed at the repo root.
methodology/index.qmd already uses the correct Path("..") / ".." pattern. This brings cpi.qmd and clovis.qmd into alignment.

After this fix, the rendered methodology pages will display the rich freshness detail instead of the fallback. Verifiable by re-rendering and grepping the output for "Latest vintage" vs "Manifest not yet created".

Flagged in the 2026-05-04 independent audit as item #2. The audit identified the symptom but misdiagnosed the cause as stale prose; this is a path bug.