### PR TITLE
fix(lrp): raise active year-window button contrast to WCAG AA

### DIFF
--- a/site/lrp.qmd
+++ b/site/lrp.qmd
@@ -447,7 +447,7 @@ print('<span id="lrp-year-window-label" style="font-weight: 600; white-space: no
 print('<div id="lrp-year-buttons" role="group" aria-labelledby="lrp-year-window-label" style="display: inline-flex; border: 1px solid #BBB; border-radius: 3px; overflow: hidden; background: white;">')
 for w in window_list:
     is_active = (w == DEFAULT_WINDOW)
-    bg = "#4F88C9" if is_active else "white"
+    bg = "#2F6FB2" if is_active else "white"
     fg = "white" if is_active else "#222"
     fw = "600" if is_active else "400"
     border_left = "" if w == window_list[0] else "border-left: 1px solid #BBB;"
@@ -696,7 +696,7 @@ _js_payload = (
     '      for (var i = 0; i < yearBtns.length; i++) {\n'
     '        var b = yearBtns[i];\n'
     '        var active = (b.getAttribute("data-window") === winKey);\n'
-    '        b.style.background = active ? "#4F88C9" : "white";\n'
+    '        b.style.background = active ? "#2F6FB2" : "white";\n'
     '        b.style.color = active ? "white" : "#222";\n'
     '        b.style.fontWeight = active ? "600" : "400";\n'
     '        b.setAttribute("aria-pressed", active ? "true" : "false");\n'
@@ -707,8 +707,8 @@ _js_payload = (
     '      var st = (stateSelect && stateSelect.value) ? stateSelect.value : window.lrpDefault.state;\n'
     '      var win = window.lrpDefault.window;\n'
     '      for (var i = 0; i < yearBtns.length; i++) {\n'
-    '        if (yearBtns[i].style.background.indexOf("rgb(79, 136, 201)") !== -1\n'
-    '            || yearBtns[i].style.background === "#4F88C9"\n'
+    '        if (yearBtns[i].style.background.indexOf("rgb(47, 111, 178)") !== -1\n'
+    '            || yearBtns[i].style.background === "#2F6FB2"\n'
     '            || yearBtns[i].dataset.lrpActive === "1") {\n'
     '          win = yearBtns[i].getAttribute("data-window") || win;\n'
     '          break;\n'


### PR DESCRIPTION
White text on #4F88C9 was ~3.69:1, below the 4.5:1 minimum required by WCAG 2.1 AA for normal text. Swaps the active button background to #2F6FB2 (white-on-#2F6FB2 is ~5.10:1, passes AA).

Updated all three call sites that drive active-button styling and state detection:

- site/lrp.qmd line 450 (Python: server-rendered initial styling)
- site/lrp.qmd line 699 (JS: re-applied styling on click)
- site/lrp.qmd lines 710-711 (JS: state-detection comparison; updates both the hex form and the rgb form rgb(47, 111, 178) the browser returns from style.background)

The two decorative #4F88C9 uses (line 228 chart marker, line 586 heading border) are intentionally left in place — non-text uses do not need 4.5:1 contrast and changing them would shift unrelated visual choices.

Audit also flagged this code path as missing aria-pressed and role=group; verified those are already implemented (lines 447, 457, 702). The audit got that part wrong, so no semantic changes here.

Flagged in the 2026-05-04 independent audit (item #4).