### PR TITLE
chore(citation): sync CITATION.cff version to match pyproject.toml

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ license: MIT
 license-url: https://opensource.org/licenses/MIT
 repository-code: https://github.com/lma-explorer/lma-explorer.github.io
 url: https://lma-explorer.github.io
-version: 0.4.0-prototype
-date-released: 2026-04-27
+version: 0.5.0-prototype
+date-released: 2026-04-30


### PR DESCRIPTION
Two-line metadata correction. CITATION.cff was at 0.4.0-prototype while pyproject.toml has been at 0.5.0-prototype since commit 192eb29 (2026-04-30). Updates the CFF version field to match and sets date-released to 2026-04-30 (when the version actually landed), not today — this is a metadata correction, not a new release.

Sweep confirmed these are the only two project-version strings in the repo. Other "version" hits are schema versions (cff-version), Python and Quarto pins in workflows, dependency pins, and the SVG XML header — all unrelated.
Out-of-scope follow-up: the audit recommended a "single source of truth" so this can't drift again. A pre-commit hook or CI check that fails when pyproject.toml and CITATION.cff disagree would do it. Filing as a separate issue/PR if desired.

Flagged in the 2026-05-04 independent audit as item #5.