### PR TITLE
docs: re-apply editorial-claim framing (item #6 redo)

### DIFF
--- a/site/glossary.qmd
+++ b/site/glossary.qmd
@@ -27,7 +27,7 @@ The skeletal-size category of a feeder animal. USDA-AMS classifies feeders into 
 The body-condition grade reflecting expected meat yield. USDA-AMS quotes 1, 1-2, 2, and lower combinations. Grade 1 indicates the muscling reflective of the indicated frame; lower grades reflect lighter muscling.
 
 ### M&L 1 (Medium and Large, muscle grade 1)
-The dominant grade combination by volume at the Clovis auction and the standard reference grade in agricultural-economics analysis of feeder-cattle prices. The platform's cash chart pages restrict to M&L 1 to keep comparisons apples-to-apples week-over-week. Other frame and muscle-grade combinations are preserved in the underlying parquet for researchers; see [Methodology → Clovis pipeline](methodology/clovis.qmd).
+The most common grade combination by volume across the committed Clovis snapshot (2017–present) and a widely-used reference grade in agricultural-economics analyses of feeder-cattle prices (e.g., Tronstad 1994, cited in [methodology / basis](methodology/basis.qmd#precedent-in-the-literature)). The platform's cash chart pages restrict to M&L 1 to keep comparisons apples-to-apples week-over-week. Other frame and muscle-grade combinations are preserved in the underlying parquet for researchers; see [Methodology → Clovis pipeline](methodology/clovis.qmd).
 
 ### Weight class
 The 100-pound bin a feeder animal falls into for pricing purposes. The platform's charts use 300–399 lb, 400–499 lb, 500–599 lb, 600–699 lb, 700–799 lb, and 800–899 lb. USDA-AMS quotes prices per cwt within each bin.
@@ -44,7 +44,7 @@ Synonyms for the 100-lb pricing class above. The MARS API field `weight_break_lo
 A weighted average where each lot's contribution is proportional to the number of head it represents. A lot of 50 head at $200 and a lot of 5 head at $250 average to (50×200 + 5×250) / (50 + 5) = $204.55, not $225. Used on the price-weight, seasonality, sell-now compare, and one-pager pages because it reflects what dollars actually flowed through the auction. The weekly-trends page currently simple-averages instead, which is disclosed prominently in its callout; a head-weighted refactor is a planned roadmap item.
 
 ### Simple-averaged mean
-The arithmetic mean across observations, ignoring head count. Faster to compute but biased toward small lots in volatile weeks. The weekly-trends page uses this; the discrepancy with head-weighted means is typically $1-3/cwt.
+The arithmetic mean across observations, ignoring head count. Faster to compute but biased toward small lots in volatile weeks. The weekly-trends page uses this; spot-checks of the committed Clovis snapshot place the discrepancy with head-weighted means at roughly $1-3/cwt in typical weeks, with actual divergence depending on within-week lot-size variation. This is a maintainer-derived estimate, not a published figure.
 
 ### Min, max, mean band
 A vertical span on a chart showing, across a window of years for the same week-of-year and weight class, the lowest observation, the highest observation, and the average. Used on the [price-weight](price-weight.qmd) page.

--- a/site/methodology/cpi.qmd
+++ b/site/methodology/cpi.qmd
@@ -9,7 +9,7 @@ toc-depth: 2
 
 When a figure on this site says it shows **real dollars**, it means nominal prices have been divided by a Consumer Price Index value to remove the effect of general price-level change. The CPI series used is the **CPI-U, All Items, U.S. City Average, Not Seasonally Adjusted** ([BLS series `CUUR0000SA0`](https://data.bls.gov/timeseries/CUUR0000SA0); see also the [BLS Handbook of Methods, CPI chapter](https://www.bls.gov/opub/hom/cpi/home.htm) for the underlying construction).
 
-NSA is used rather than seasonally adjusted CPI because seasonal-adjustment patterns reflect a general consumer basket and do not cleanly transfer to livestock prices; the actual price level a producer faced in a given month is what NSA reports.
+NSA is used rather than seasonally adjusted CPI because the BLS seasonal-adjustment factors are constructed for a general consumer basket and are not designed to model livestock-price seasonality; the actual price level a producer faced in a given month is what NSA reports. This is a maintainer methodological choice rather than a settled standard — readers preferring the SA series can substitute BLS's `CUSR0000SA0` for the platform's `CUUR0000SA0` deflator.
 
 ## Where the data comes from
 

--- a/site/weekly-trends.qmd
+++ b/site/weekly-trends.qmd
@@ -10,7 +10,7 @@ toc-depth: 2
 :::
 
 ::: {.callout-note appearance="simple"}
-**Aggregation note for multi-lot weeks.** This page currently simple-averages multiple lots within the same (week, class, weight bin) cell. The other chart-shelf pages (price–weight, seasonality, basis, sell-now compare, one-pager) use head-weighted means. Where lot sizes vary substantially within a week, the simple-average value can differ by ~$1-3/cwt from the head-weighted version. A head-weighted refactor is queued; the methodology page documents the choice.
+**Aggregation note for multi-lot weeks.** This page currently simple-averages multiple lots within the same (week, class, weight bin) cell. The other chart-shelf pages (price–weight, seasonality, basis, sell-now compare, one-pager) use head-weighted means. Where lot sizes vary substantially within a week, the simple-average value can differ from the head-weighted version by roughly $1-3/cwt in spot-checks of the committed snapshot — actual divergence depends on the lot-size mix in any given week, and this estimate is the maintainer's own observation rather than a published figure. A head-weighted refactor is queued; the methodology page documents the choice.
 :::
 
 ::: {.callout-tip appearance="simple"}


### PR DESCRIPTION
Three single-line edits that were nominally part of PR #16 but dropped out of that squash — main currently has the pre-edit wording on glossary, weekly-trends, and methodology/cpi. This PR re-applies the wording.

Substantive content unchanged from PR #16's intended scope:

- glossary.qmd 'M&L 1 dominant grade combination' -> 'most common ... across the committed Clovis snapshot (2017-present)' with Tronstad 1994 anchor.
- glossary.qmd '$1-3/cwt typically' -> spot-check estimate framing with maintainer-derived disclaimer.
- weekly-trends.qmd same $1-3/cwt claim -> same framing for surface-consistency.
- methodology/cpi.qmd 'do not cleanly transfer' -> 'not designed to model livestock-price seasonality' with maintainer methodological-choice framing and CUSR0000SA0 substitute pointer.

Flagged in the 2026-05-04 independent audit (item #6).