### PR TITLE
feat(clovis): add symmetric rolling-median spike screener for the cleaned weekly aggregate

### DIFF
--- a/pipelines/clovis/clean.py
+++ b/pipelines/clovis/clean.py
@@ -56,7 +56,7 @@ import json
 import math
 import sys
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np

--- a/pipelines/clovis/clean.py
+++ b/pipelines/clovis/clean.py
@@ -1,0 +1,501 @@
+"""Aggregate per-pen Clovis observations to a cleaned weekly series.
+
+Reads the per-pen artifacts written by ``snapshot.py`` (live MARS-era) and
+the one-time historical Era B block, aggregates pens to a weekly series in
+100-lb weight classes (``300-399`` … ``800-899`` lb) using a head-count-
+weighted mean of ``price_avg``, deflates each weekly observation to the
+December-2025 base month using CPI-U All Items NSA, and applies a symmetric
+rolling-median ratio test to replace obvious data-reporting spikes with a
+local median.
+
+Outputs (one parquet, one CSV log, one manifest entry):
+
+    data/processed/clovis_weekly_cleaned_<YYYY-MM-DD>.parquet
+    data/processed/clovis_weekly_cleaned_latest.parquet
+    data/processed/clovis_spike_log_<YYYY-MM-DD>.csv
+    data/processed/clovis_weekly_cleaned_MANIFEST.json   (append-only)
+
+Cleaned-weekly schema (tidy long, one row per (date, sex, weight_class)):
+
+    auction_date     : datetime64[ns]
+    sex              : string  ("Steers" / "Heifers")
+    weight_class     : string  ("300-399" … "800-899")
+    head_count       : Int64   total head in the weekly aggregate
+    n_pens           : Int32   number of pens contributing to the aggregate
+    price_nominal    : float   head-count-weighted mean of pen ``price_avg`` ($/cwt)
+    price_real       : float   ``price_nominal`` deflated to Dec-2025 dollars
+    cpi_at_obs       : float   CPI-U value at the observation month
+    spike_replaced   : bool    True if this row was a spike-replacement
+    direction        : string  "low" / "high" / "" — only set if replaced
+    source_eras      : string  comma-joined source-era set ("MARS" / "EraB" / "MARS,EraB")
+    vintage          : datetime64[ns]
+
+Spike replacement (the same rule used by the paper-figures pipeline):
+
+    - 13-week centered rolling median per (sex, weight_class)
+    - Flag if abs(ratio - 1) puts the row outside [ratio_lo, ratio_hi]
+      (i.e. ratio <= 0.60 or ratio >= 1/0.60 ≈ 1.67), AND
+    - the absolute deviation from the local median exceeds ``min_abs`` ($50)
+    - Flagged ``price_real`` is replaced with the local median; ``price_nominal``
+      is recomputed via ``price_real * (cpi_at_obs / CPI_BASE)`` so the two
+      series stay internally consistent
+    - Every replacement is appended to ``clovis_spike_log_<vintage>.csv``
+
+The cleaner runs symmetrically on the high and low side; an empty spike log
+is itself a deliverable (publishes "no anomalies in this vintage").
+
+Usage:
+    python -m pipelines.clovis.clean
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROCESSED_DIR = REPO_ROOT / "data" / "processed"
+
+ERA_A_PATH = PROCESSED_DIR / "clovis_latest.parquet"
+ERA_B_PATH = PROCESSED_DIR / "clovis_historical_era_b_latest.parquet"
+CPI_PATH = PROCESSED_DIR / "cpi_latest.parquet"
+
+CLEANED_LATEST_NAME = "clovis_weekly_cleaned_latest.parquet"
+CLEANED_VINTAGE_TEMPLATE = "clovis_weekly_cleaned_{vintage}.parquet"
+SPIKE_LOG_TEMPLATE = "clovis_spike_log_{vintage}.csv"
+CLEANED_MANIFEST_PATH = PROCESSED_DIR / "clovis_weekly_cleaned_MANIFEST.json"
+
+# Filter to the analytical core used on the chart pages.
+KEEP_COMMODITY = "Feeder Cattle"
+KEEP_FRAME = "Medium and Large"
+KEEP_MUSCLE_GRADE = "1"
+KEEP_CLASSES = ("Steers", "Heifers")
+
+# 100-lb weight ladder used by the chart pages.
+WEIGHT_LADDER = (
+    "300-399",
+    "400-499",
+    "500-599",
+    "600-699",
+    "700-799",
+    "800-899",
+)
+
+# Deflation basis: December 2025 — pinned so that recomputed real-dollar
+# numbers stay stable across BLS revisions until a deliberate basis change.
+DEFLATION_BASIS_PERIOD = "2025-12"
+
+
+@dataclass(frozen=True)
+class CleanConfig:
+    """Spike-detection thresholds. Held as a dataclass so tests can override."""
+
+    rolling_window_weeks: int = 13
+    rolling_min_periods: int = 5
+    ratio_lo: float = 0.60
+    ratio_hi: float = 1.0 / 0.60  # ≈ 1.67, symmetric to ratio_lo
+    min_abs_dev: float = 50.0
+
+
+CFG = CleanConfig()
+
+
+# --------------------------------------------------------------------------- #
+# Bin assignment                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def assign_100lb_bin(low: float | None, avg: float | None) -> str | None:
+    """Snap a per-pen row to a 100-lb bin label like ``'400-499'``.
+
+    Prefer ``weight_break_low`` (the AMS-published 50-lb bin floor); fall back
+    to ``avg_weight`` when the bin is missing (some MARS rows lack
+    ``weight_break_low``). Returns ``None`` for pens outside the 300-899 lb
+    analytical window.
+    """
+    w: float | None = None
+    if low is not None and not (isinstance(low, float) and math.isnan(low)):
+        try:
+            w = float(low)
+        except (TypeError, ValueError):
+            w = None
+    if w is None and avg is not None and not (isinstance(avg, float) and math.isnan(avg)):
+        try:
+            w = float(avg)
+        except (TypeError, ValueError):
+            w = None
+    if w is None or math.isnan(w):
+        return None
+    lo = int(math.floor(w / 100.0) * 100)
+    if lo < 300 or lo > 800:
+        return None
+    return f"{lo}-{lo + 99}"
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def aggregate_weekly(pens: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate per-pen rows to a weekly head-count-weighted DataFrame.
+
+    Returns a tidy-long DataFrame with columns:
+    ``auction_date, sex, weight_class, head_count, n_pens, price_nominal,
+    source_eras``.
+    """
+    if pens.empty:
+        return pd.DataFrame(
+            columns=[
+                "auction_date",
+                "sex",
+                "weight_class",
+                "head_count",
+                "n_pens",
+                "price_nominal",
+                "source_eras",
+            ]
+        )
+
+    # Apply the analytical filter (M&L 1, Steers/Heifers, Feeder Cattle, $/cwt).
+    df = pens.loc[
+        (pens["commodity"].astype(str) == KEEP_COMMODITY)
+        & (pens["class"].isin(KEEP_CLASSES))
+        & (pens["frame"].astype(str).str.strip() == KEEP_FRAME)
+        & (pens["muscle_grade"].astype(str).str.strip() == KEEP_MUSCLE_GRADE)
+    ].copy()
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "auction_date",
+                "sex",
+                "weight_class",
+                "head_count",
+                "n_pens",
+                "price_nominal",
+                "source_eras",
+            ]
+        )
+
+    df["weight_class"] = df.apply(
+        lambda r: assign_100lb_bin(r.get("weight_break_low"), r.get("avg_weight")),
+        axis=1,
+    )
+    df = df.dropna(subset=["weight_class", "price_avg"])
+    df = df.loc[df["price_avg"] > 0].copy()
+
+    # head_count missing or non-positive → fall back to weight 1 (treat as one
+    # head). Keeps the aggregate well-defined; logged elsewhere if needed.
+    hc = pd.to_numeric(df["head_count"], errors="coerce").fillna(1.0)
+    hc = hc.where(hc > 0, 1.0)
+    df["_hc"] = hc
+    df["_wp"] = df["price_avg"] * hc
+
+    grp = df.groupby(["auction_date", "class", "weight_class"], as_index=False).agg(
+        sum_wp=("_wp", "sum"),
+        sum_hc=("_hc", "sum"),
+        n_pens=("price_avg", "size"),
+        source_eras=("_source_era", lambda s: ",".join(sorted(set(s)))),
+    )
+    grp["price_nominal"] = grp["sum_wp"] / grp["sum_hc"]
+    grp = grp.rename(columns={"class": "sex", "sum_hc": "head_count"})
+    grp["head_count"] = grp["head_count"].round().astype("Int64")
+    grp["n_pens"] = grp["n_pens"].astype("Int32")
+    return grp[
+        [
+            "auction_date",
+            "sex",
+            "weight_class",
+            "head_count",
+            "n_pens",
+            "price_nominal",
+            "source_eras",
+        ]
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# CPI deflation                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def load_cpi_map() -> tuple[dict[str, float], float, str]:
+    """Read CPI-U from ``cpi_latest.parquet`` and return a {YYYY-MM: cpi_u}
+    map plus the basis CPI value for ``DEFLATION_BASIS_PERIOD``.
+    """
+    cpi = pd.read_parquet(CPI_PATH)
+    cpi = cpi.copy()
+    cpi["period"] = pd.to_datetime(cpi["period"]).dt.strftime("%Y-%m")
+    cpi_map = dict(zip(cpi["period"], cpi["cpi_u"].astype(float)))
+    if DEFLATION_BASIS_PERIOD not in cpi_map:
+        raise ValueError(
+            f"basis period {DEFLATION_BASIS_PERIOD} not present in CPI series; "
+            f"latest available is {max(cpi_map)!r}"
+        )
+    return cpi_map, float(cpi_map[DEFLATION_BASIS_PERIOD]), DEFLATION_BASIS_PERIOD
+
+
+def deflate(weekly: pd.DataFrame, cpi_map: dict[str, float], cpi_base: float) -> pd.DataFrame:
+    """Add ``cpi_at_obs`` and ``price_real`` columns. Drops rows whose
+    observation month has no published CPI yet.
+    """
+    out = weekly.copy()
+    out["_yyyymm"] = pd.to_datetime(out["auction_date"]).dt.strftime("%Y-%m")
+    out["cpi_at_obs"] = out["_yyyymm"].map(cpi_map)
+    n_missing = int(out["cpi_at_obs"].isna().sum())
+    if n_missing:
+        print(
+            f"[clean] dropping {n_missing} weekly row(s) past latest CPI month — "
+            f"no deflator yet for those weeks.",
+            file=sys.stderr,
+        )
+    out = out.dropna(subset=["cpi_at_obs"]).copy()
+    out["price_real"] = out["price_nominal"] * (cpi_base / out["cpi_at_obs"])
+    return out.drop(columns=["_yyyymm"])
+
+
+# --------------------------------------------------------------------------- #
+# Spike replacement                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def replace_spikes(
+    weekly_real: pd.DataFrame, cpi_base: float, cfg: CleanConfig = CFG
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Symmetric rolling-median ratio test on ``price_real``.
+
+    For each (sex, weight_class) group, computes a centered rolling-median of
+    ``price_real`` over a 13-week window. Flags any row whose ratio to that
+    median is at or beyond [ratio_lo, ratio_hi] AND whose absolute deviation
+    from the median exceeds ``min_abs_dev`` ($50). Replaces the flagged row's
+    ``price_real`` with the local median and recomputes ``price_nominal`` so
+    the two series stay internally consistent.
+
+    Returns
+    -------
+    cleaned_df, spike_log
+        ``cleaned_df`` mirrors ``weekly_real`` schema with two added columns
+        (``spike_replaced``, ``direction``). ``spike_log`` is one row per
+        replacement with the before-and-after numbers.
+    """
+    out = weekly_real.copy().sort_values(
+        ["sex", "weight_class", "auction_date"]
+    ).reset_index(drop=True)
+
+    out["spike_replaced"] = False
+    out["direction"] = ""
+
+    log_rows: list[dict] = []
+
+    for (sex, wc), idxs in out.groupby(["sex", "weight_class"]).groups.items():
+        idxs = list(idxs)
+        sub = out.loc[idxs, "price_real"]
+        med = sub.rolling(
+            cfg.rolling_window_weeks,
+            center=True,
+            min_periods=cfg.rolling_min_periods,
+        ).median()
+        with np.errstate(divide="ignore", invalid="ignore"):
+            ratio = sub / med
+        diff = (sub - med).abs()
+        mask = (
+            ((ratio <= cfg.ratio_lo) | (ratio >= cfg.ratio_hi))
+            & (diff > cfg.min_abs_dev)
+        ).fillna(False)
+
+        for pos_idx, do_replace in zip(idxs, mask):
+            if not do_replace:
+                continue
+            local_med = float(med.loc[pos_idx])
+            orig_real = float(out.at[pos_idx, "price_real"])
+            orig_nom = float(out.at[pos_idx, "price_nominal"])
+            cpi_obs = float(out.at[pos_idx, "cpi_at_obs"])
+            new_nom = local_med * (cpi_obs / cpi_base)
+            direction = "low" if orig_real / local_med <= cfg.ratio_lo else "high"
+
+            log_rows.append(
+                {
+                    "auction_date": out.at[pos_idx, "auction_date"],
+                    "sex": sex,
+                    "weight_class": wc,
+                    "direction": direction,
+                    "price_real_orig": round(orig_real, 4),
+                    "price_real_replaced": round(local_med, 4),
+                    "price_nominal_orig": round(orig_nom, 4),
+                    "price_nominal_replaced": round(new_nom, 4),
+                    "local_median_real": round(local_med, 4),
+                    "ratio": round(orig_real / local_med, 4),
+                    "cpi_at_obs": cpi_obs,
+                }
+            )
+
+            out.at[pos_idx, "price_real"] = local_med
+            out.at[pos_idx, "price_nominal"] = new_nom
+            out.at[pos_idx, "spike_replaced"] = True
+            out.at[pos_idx, "direction"] = direction
+
+    log_df = pd.DataFrame(
+        log_rows,
+        columns=[
+            "auction_date",
+            "sex",
+            "weight_class",
+            "direction",
+            "price_real_orig",
+            "price_real_replaced",
+            "price_nominal_orig",
+            "price_nominal_replaced",
+            "local_median_real",
+            "ratio",
+            "cpi_at_obs",
+        ],
+    )
+    return out, log_df
+
+
+# --------------------------------------------------------------------------- #
+# Vintage stamping + manifest                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _vintage_tag() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _write_manifest_entry(
+    vintage_tag: str,
+    snapshot_path: Path,
+    spike_log_path: Path,
+    row_count: int,
+    spike_count: int,
+    cpi_base: float,
+) -> None:
+    entry = {
+        "vintage": vintage_tag,
+        "file": snapshot_path.relative_to(REPO_ROOT).as_posix(),
+        "spike_log": spike_log_path.relative_to(REPO_ROOT).as_posix(),
+        "sha256": hashlib.sha256(snapshot_path.read_bytes()).hexdigest(),
+        "rows": row_count,
+        "spikes_replaced": spike_count,
+        "deflation_basis": DEFLATION_BASIS_PERIOD,
+        "cpi_base": round(cpi_base, 4),
+        "rolling_window_weeks": CFG.rolling_window_weeks,
+        "ratio_lo": CFG.ratio_lo,
+        "ratio_hi": round(CFG.ratio_hi, 4),
+        "min_abs_dev": CFG.min_abs_dev,
+        "written_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    if CLEANED_MANIFEST_PATH.exists():
+        with CLEANED_MANIFEST_PATH.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    else:
+        manifest = {"slug": "clovis_weekly_cleaned", "entries": []}
+    manifest["entries"] = [
+        e for e in manifest.get("entries", []) if e.get("vintage") != vintage_tag
+    ]
+    manifest["entries"].append(entry)
+    manifest["entries"].sort(key=lambda e: e["vintage"])
+    with CLEANED_MANIFEST_PATH.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=False)
+
+
+# --------------------------------------------------------------------------- #
+# Source-aware loaders                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _load_per_pen_with_era_label() -> pd.DataFrame:
+    """Read both per-pen sources and stamp each row with its source era.
+
+    Era-window precedence here matches ``load.py``: most-recent-vintage-wins
+    on the dedupe key. We tag rows with their source era so the cleaned
+    weekly artifact's ``source_eras`` column is honest about each cell's
+    provenance.
+    """
+    frames: list[pd.DataFrame] = []
+    if ERA_A_PATH.exists():
+        a = pd.read_parquet(ERA_A_PATH)
+        a["_source_era"] = "MARS"
+        frames.append(a)
+    if ERA_B_PATH.exists():
+        b = pd.read_parquet(ERA_B_PATH)
+        b["_source_era"] = "EraB"
+        frames.append(b)
+    if not frames:
+        raise FileNotFoundError(
+            f"neither {ERA_A_PATH} nor {ERA_B_PATH} exists; nothing to clean"
+        )
+    df = pd.concat(frames, ignore_index=True, sort=False)
+    df["auction_date"] = pd.to_datetime(df["auction_date"])
+    return df
+
+
+# --------------------------------------------------------------------------- #
+# Entry point                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate per-pen Clovis observations to a cleaned weekly series."
+    )
+    parser.parse_args(argv)
+
+    PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+
+    pens = _load_per_pen_with_era_label()
+    weekly = aggregate_weekly(pens)
+    if weekly.empty:
+        print(
+            "[clean] no weekly rows produced after filter+aggregate; "
+            "skipping cleaned-artifact write.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cpi_map, cpi_base, _ = load_cpi_map()
+    weekly_real = deflate(weekly, cpi_map, cpi_base)
+
+    cleaned, spike_log = replace_spikes(weekly_real, cpi_base)
+
+    vintage = _vintage_tag()
+    vintage_d = pd.Timestamp(vintage)
+    cleaned["vintage"] = vintage_d
+
+    snapshot_path = PROCESSED_DIR / CLEANED_VINTAGE_TEMPLATE.format(vintage=vintage)
+    latest_path = PROCESSED_DIR / CLEANED_LATEST_NAME
+    spike_log_path = PROCESSED_DIR / SPIKE_LOG_TEMPLATE.format(vintage=vintage)
+
+    cleaned.to_parquet(snapshot_path, index=False)
+    cleaned.to_parquet(latest_path, index=False)
+    spike_log.to_csv(spike_log_path, index=False)
+    _write_manifest_entry(
+        vintage,
+        snapshot_path,
+        spike_log_path,
+        row_count=len(cleaned),
+        spike_count=int(cleaned["spike_replaced"].sum()),
+        cpi_base=cpi_base,
+    )
+
+    print(f"[clean] wrote {snapshot_path} ({len(cleaned)} weekly rows)")
+    print(f"[clean] wrote {latest_path}")
+    print(
+        f"[clean] wrote {spike_log_path} "
+        f"({len(spike_log)} replacement(s))"
+    )
+    print(f"[clean] updated {CLEANED_MANIFEST_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/clovis/snapshot.py
+++ b/pipelines/clovis/snapshot.py
@@ -216,7 +216,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Write a validated Clovis (AMS_1781) vintage snapshot.",
     )
-    parser.parse_args(argv)
+    parser.add_argument(
+        "--skip-clean",
+        action="store_true",
+        help="Skip the post-snapshot cleaned-weekly aggregate step. "
+        "Use when re-running the snapshot in isolation; the cleaner is "
+        "normally invoked as the final step so the cleaned-weekly artifact "
+        "stays in lockstep with the per-pen snapshot.",
+    )
+    args = parser.parse_args(argv)
 
     PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
     payload = _load_raw()
@@ -240,6 +248,24 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[snapshot] wrote {snapshot_path} ({len(df)} rows)")
     print(f"[snapshot] wrote {latest_path}")
     print(f"[snapshot] updated {MANIFEST_PATH}")
+
+    # Refresh the cleaned-weekly aggregate so the chart pages and the
+    # methodology page see consistent inputs after every per-pen snapshot.
+    # Imported lazily to avoid pulling numpy when only the per-pen step is
+    # needed (tests, debugging).
+    if not args.skip_clean:
+        from pipelines.clovis import clean as _clean
+
+        rc = _clean.main([])
+        if rc != 0:
+            print(
+                "[snapshot] cleaner returned non-zero; per-pen snapshot still "
+                "written. Re-run `python -m pipelines.clovis.clean` after "
+                "diagnosing.",
+                file=sys.stderr,
+            )
+            return rc
+
     return 0
 
 

--- a/site/methodology/clovis.qmd
+++ b/site/methodology/clovis.qmd
@@ -103,6 +103,63 @@ Two reasons to restrict the chart to M&L 1:
 
 All other frame-and-grade combinations (`Medium`, `Large`, `Small and Medium`, muscle grades 2 and 1-2, etc.) are preserved in the snapshot but filtered out in the site's chart code rather than in the pipeline. Adding those as reader-selectable filters is a Phase 2 enhancement.
 
+## Spike screening on the cleaned weekly aggregate
+
+The per-pen snapshot above is the raw artifact. A separate downstream step aggregates pens to a head-count-weighted weekly mean per (sex, weight-class) bin, deflates each weekly observation to December 2025 dollars using the BLS CPI-U series, and applies a symmetric rolling-median ratio test to replace obvious data-reporting spikes. The output is a separate parquet at `data/processed/clovis_weekly_cleaned_latest.parquet` with one row per (auction date, sex, 100-lb bin); every replacement is logged to `clovis_spike_log_<vintage>.csv` alongside it.
+
+The detection rule is symmetric — the same threshold catches both implausibly low and implausibly high observations:
+
+- For each (sex, weight-class) bin, compute a 13-week centered rolling median of `price_real` (the deflated weekly mean).
+- A weekly observation is flagged if its ratio to the local median is at or beyond `[0.60, 1/0.60 ≈ 1.67]` **and** its absolute deviation from the local median exceeds `$50/cwt`.
+- A flagged value is replaced with the local median; the corresponding nominal value is recomputed via the observation's CPI ratio so the two series stay internally consistent.
+- The threshold and window are pipeline-level parameters in `pipelines/clovis/clean.py` (`CleanConfig`); changing them is a deliberate, reviewed action.
+
+The rationale for each piece of the rule:
+
+- **The 13-week centered window.** Wide enough that a single bad weekly cell cannot pull the median (the focal week contributes 1/13 to its own neighborhood). Narrow enough to track real seasonal price movement; a longer window would treat normal cyclical lows/highs as spikes.
+- **The `0.60 / 1.67` ratio band.** A weekly mean that is roughly half (or twice) the local median is implausible for feeder-cattle prices, which move on cycle and seasonal scales much slower than that. The two thresholds are reciprocals so the same statistic catches drops and spikes symmetrically.
+- **The `$50/cwt` absolute floor.** A noise floor: when the local median is itself small (rare on this series, but possible if a bin is quiet), small absolute fluctuations should not trip the ratio test. `$50/cwt` is loose enough to never flag legitimate variation in a normal-priced week and strict enough to catch every reporting anomaly observed in our reference samples.
+- **Replace, not drop.** The cleaned weekly artifact is meant to feed continuous time-series charts; dropping a row leaves a gap that a downstream renderer would fill silently. Replacing with the local median preserves the line and is more honest about the pipeline's hand on the chart. The original (unreplaced) per-pen rows are preserved in `clovis_latest.parquet` and `clovis_historical_era_b_latest.parquet`; nothing is lost from the underlying record.
+
+The rule is symmetric and unambiguous, so the audit trail is the test of integrity: every row of every spike log is the rule's complete output for that vintage. An empty log is the same kind of evidence as a long log — it publishes "no anomalies in this vintage" rather than implying a silent pass.
+
+```{python}
+#| echo: false
+#| label: clovis-cleaned-freshness
+
+from pathlib import Path
+import json
+from IPython.display import Markdown
+
+CLEAN_MANIFEST = Path("..") / ".." / "data" / "processed" / "clovis_weekly_cleaned_MANIFEST.json"
+if CLEAN_MANIFEST.exists():
+    with CLEAN_MANIFEST.open("r", encoding="utf-8") as f:
+        m = json.load(f)
+    entries = m.get("entries", [])
+    if entries:
+        e = entries[-1]
+        freshness = (
+            f"- **Cleaned-weekly vintage**: `{e.get('vintage','—')}`  \n"
+            f"- **Rows in the cleaned artifact**: {e.get('rows','—'):,}  \n"
+            f"- **Spike replacements in this vintage**: {e.get('spikes_replaced','—')}  \n"
+            f"- **Deflation basis**: {e.get('deflation_basis','—')}  \n"
+            f"- **Rule**: window={e.get('rolling_window_weeks','—')}w, "
+            f"ratio∈[{e.get('ratio_lo','—')}, {e.get('ratio_hi','—')}], "
+            f"min |dev|=${e.get('min_abs_dev','—')}/cwt"
+        )
+    else:
+        freshness = "_No cleaned-weekly vintages committed yet. Will populate after the next snapshot run that invokes `pipelines/clovis/clean.py`._"
+else:
+    freshness = "_Cleaned-weekly manifest not yet created. Expected path: `data/processed/clovis_weekly_cleaned_MANIFEST.json`._"
+Markdown(freshness)
+```
+
+What this rule does **not** do:
+
+- It does not address fragile summary statistics built on top of the cleaned series. A `min` or `max` of weekly means over many years is an order statistic and stays sensitive to whichever single week did not trip the ratio band; a `p5 / mean / p95` band is the more honest summary and is recommended for any chart that exposes "extreme" values to readers.
+- It does not detect cross-bin structural inversions (e.g., a heavier weight-class trading higher per-cwt than a lighter one in the same week). In every reference sample to date, such inversions also failed the ratio test on the cleaner's own bin and were caught for that reason; a future enhancement could add a cross-bin consistency check explicitly.
+- It does not deflate using a producer-side index. The current basis is CPI-U All Items NSA, which expresses prices in general-consumer purchasing power; a producer-receipts deflator (e.g., PPI Farm Products) is a Phase 2 candidate.
+
 ## The schema-hash validator
 
 Before any new vintage is snapshotted, the pipeline computes a SHA-256 over the sorted key sets at the root of the MARS response envelope *and* the first row of `results`. That hash is compared to `pipelines/clovis/expected_schema.sha256`. Any change — a renamed field, an added field, a removed field — produces a mismatch and fails the pipeline.

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,417 @@
+"""Tests for `pipelines/clovis/clean.py`.
+
+The cleaner has four pure-function pieces with non-trivial logic:
+
+    * `assign_100lb_bin` — bin assignment, including the avg_weight fallback
+    * `aggregate_weekly`  — head-count-weighted weekly aggregation under the
+                            M&L 1, Steers/Heifers, $/cwt filter
+    * `deflate`           — CPI ratio applied per observation month
+    * `replace_spikes`    — symmetric rolling-median ratio test, replacement
+                            with local median, audit log generation, and the
+                            invariant that cleaned nominal stays in sync with
+                            cleaned real
+
+Every test uses synthetic in-memory inputs. No parquet reads, no CPI
+file reads, no network.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from pipelines.clovis.clean import (
+    CleanConfig,
+    aggregate_weekly,
+    assign_100lb_bin,
+    deflate,
+    replace_spikes,
+)
+
+
+# --------------------------------------------------------------------------- #
+# assign_100lb_bin                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "low,avg,expected",
+    [
+        # weight_break_low present → use it directly (floor to 100)
+        (400, 420, "400-499"),
+        (450, 480, "400-499"),
+        (300, 350, "300-399"),
+        (800, 820, "800-899"),
+        # weight_break_low missing → fall back to avg_weight
+        (None, 520, "500-599"),
+        (None, 699, "600-699"),
+        # both missing → None
+        (None, None, None),
+        # outside the analytical window → None (lower & upper bounds)
+        (200, 250, None),
+        (900, 950, None),
+        # NaN handling on avg fallback
+        (None, float("nan"), None),
+    ],
+)
+def test_assign_100lb_bin(low, avg, expected) -> None:
+    assert assign_100lb_bin(low, avg) == expected
+
+
+def test_assign_100lb_bin_low_takes_priority_over_avg() -> None:
+    """If both fields are present, the bin floor uses weight_break_low.
+    Common when MARS reports a 350-399 bin with avg_weight=380 — the
+    headline bin is 300-399 (floor 350 = 300), not 300-399 from avg."""
+    # low=350 → floor(350/100)*100 = 300 → "300-399"
+    # avg=380 → would give "300-399" too, but the test verifies precedence
+    assert assign_100lb_bin(350, 380) == "300-399"
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_weekly                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _pen_row(
+    auction_date: str,
+    sex: str = "Steers",
+    frame: str = "Medium and Large",
+    muscle_grade: str = "1",
+    weight_break_low: float | None = 500,
+    avg_weight: float | None = 525,
+    head_count: int = 50,
+    price_avg: float = 200.0,
+    source_era: str = "MARS",
+) -> dict:
+    return {
+        "auction_date": pd.Timestamp(auction_date),
+        "commodity": "Feeder Cattle",
+        "class": sex,
+        "frame": frame,
+        "muscle_grade": muscle_grade,
+        "weight_break_low": weight_break_low,
+        "weight_break_high": (weight_break_low + 49) if weight_break_low else None,
+        "avg_weight": avg_weight,
+        "head_count": head_count,
+        "price_avg": price_avg,
+        "_source_era": source_era,
+    }
+
+
+def test_aggregate_weekly_head_count_weighting() -> None:
+    """Two pens in the same (date, sex, weight_class) cell with different
+    head counts: the aggregate price is the head-count-weighted mean, not
+    the simple mean."""
+    pens = pd.DataFrame(
+        [
+            _pen_row(
+                "2024-01-03", weight_break_low=500, head_count=10, price_avg=180.0
+            ),
+            _pen_row(
+                "2024-01-03", weight_break_low=500, head_count=90, price_avg=200.0
+            ),
+        ]
+    )
+    out = aggregate_weekly(pens)
+    assert len(out) == 1
+    row = out.iloc[0]
+    expected = (10 * 180.0 + 90 * 200.0) / 100  # = 198.0
+    assert row["price_nominal"] == pytest.approx(expected)
+    assert row["head_count"] == 100
+    assert row["n_pens"] == 2
+
+
+def test_aggregate_weekly_filter_drops_non_M_and_L_1() -> None:
+    """Pens outside the analytical filter (Medium 2, Large 1, etc.) drop
+    out before aggregation."""
+    pens = pd.DataFrame(
+        [
+            _pen_row("2024-01-03", frame="Medium and Large", muscle_grade="1"),
+            _pen_row("2024-01-03", frame="Medium and Large", muscle_grade="2"),
+            _pen_row("2024-01-03", frame="Medium", muscle_grade="1"),
+            _pen_row("2024-01-03", frame="Large", muscle_grade="1"),
+        ]
+    )
+    out = aggregate_weekly(pens)
+    # Only the first row survives the filter
+    assert len(out) == 1
+    assert out.iloc[0]["sex"] == "Steers"
+    assert out.iloc[0]["weight_class"] == "500-599"
+
+
+def test_aggregate_weekly_filter_keeps_steers_and_heifers_only() -> None:
+    pens = pd.DataFrame(
+        [
+            _pen_row("2024-01-03", sex="Steers"),
+            _pen_row("2024-01-03", sex="Heifers"),
+            _pen_row("2024-01-03", sex="Bulls"),
+        ]
+    )
+    out = aggregate_weekly(pens)
+    sexes = set(out["sex"].unique())
+    assert sexes == {"Steers", "Heifers"}
+
+
+def test_aggregate_weekly_empty_input_returns_empty_frame() -> None:
+    out = aggregate_weekly(pd.DataFrame())
+    assert out.empty
+    # Schema is still well-defined
+    expected_cols = {
+        "auction_date",
+        "sex",
+        "weight_class",
+        "head_count",
+        "n_pens",
+        "price_nominal",
+        "source_eras",
+    }
+    assert set(out.columns) == expected_cols
+
+
+def test_aggregate_weekly_records_source_era_set() -> None:
+    """If a (date, sex, bin) cell receives pens from both eras, the
+    source_eras column lists both."""
+    pens = pd.DataFrame(
+        [
+            _pen_row("2019-04-17", source_era="EraB"),
+            _pen_row("2019-04-17", source_era="MARS"),
+        ]
+    )
+    out = aggregate_weekly(pens)
+    assert len(out) == 1
+    assert out.iloc[0]["source_eras"] == "EraB,MARS"
+
+
+# --------------------------------------------------------------------------- #
+# deflate                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_deflate_at_basis_month_is_identity() -> None:
+    weekly = pd.DataFrame(
+        [
+            {
+                "auction_date": pd.Timestamp("2025-12-10"),
+                "sex": "Steers",
+                "weight_class": "500-599",
+                "head_count": 100,
+                "n_pens": 1,
+                "price_nominal": 250.0,
+                "source_eras": "MARS",
+            }
+        ]
+    )
+    cpi_map = {"2025-12": 324.0}
+    out = deflate(weekly, cpi_map, cpi_base=324.0)
+    assert out.iloc[0]["price_real"] == pytest.approx(250.0)
+
+
+def test_deflate_older_month_inflates_to_real() -> None:
+    """A 2002 nominal $40/cwt at CPI=180 deflates to ~$72/cwt in
+    Dec-2025 dollars at CPI=324 — pin the formula end-to-end."""
+    weekly = pd.DataFrame(
+        [
+            {
+                "auction_date": pd.Timestamp("2002-04-27"),
+                "sex": "Heifers",
+                "weight_class": "600-699",
+                "head_count": 30,
+                "n_pens": 1,
+                "price_nominal": 40.0,
+                "source_eras": "MARS",
+            }
+        ]
+    )
+    cpi_map = {"2002-04": 180.0, "2025-12": 324.0}
+    out = deflate(weekly, cpi_map, cpi_base=324.0)
+    assert out.iloc[0]["price_real"] == pytest.approx(40.0 * 324.0 / 180.0)
+
+
+def test_deflate_drops_rows_with_no_cpi_for_their_month() -> None:
+    weekly = pd.DataFrame(
+        [
+            {
+                "auction_date": pd.Timestamp("2030-01-07"),
+                "sex": "Steers",
+                "weight_class": "500-599",
+                "head_count": 50,
+                "n_pens": 1,
+                "price_nominal": 300.0,
+                "source_eras": "MARS",
+            }
+        ]
+    )
+    cpi_map = {"2025-12": 324.0}  # no 2030 entry
+    out = deflate(weekly, cpi_map, cpi_base=324.0)
+    assert out.empty
+
+
+# --------------------------------------------------------------------------- #
+# replace_spikes                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def _make_clean_series(
+    sex: str = "Heifers",
+    weight_class: str = "600-699",
+    n_weeks: int = 30,
+    price_real: float = 200.0,
+) -> pd.DataFrame:
+    """Build a baseline of `n_weeks` weekly observations with a flat
+    `price_real` and a constant deflator. Tests inject spikes on top."""
+    dates = pd.date_range("2020-01-08", periods=n_weeks, freq="7D")
+    return pd.DataFrame(
+        {
+            "auction_date": dates,
+            "sex": sex,
+            "weight_class": weight_class,
+            "head_count": [50] * n_weeks,
+            "n_pens": [1] * n_weeks,
+            "price_nominal": [price_real] * n_weeks,  # CPI ratio = 1 throughout
+            "cpi_at_obs": [324.0] * n_weeks,
+            "price_real": [price_real] * n_weeks,
+            "source_eras": ["MARS"] * n_weeks,
+        }
+    )
+
+
+def test_replace_spikes_flags_and_replaces_a_low_outlier() -> None:
+    df = _make_clean_series(price_real=200.0)
+    # Inject a 50%-of-median drop in the middle of the series.
+    df.loc[15, "price_real"] = 100.0
+    df.loc[15, "price_nominal"] = 100.0  # CPI ratio still 1.0 → both move together
+
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+
+    spike_rows = cleaned.loc[cleaned["spike_replaced"]]
+    assert len(spike_rows) == 1
+    assert spike_rows.iloc[0]["direction"] == "low"
+    # Replacement is the local median (200.0)
+    assert spike_rows.iloc[0]["price_real"] == pytest.approx(200.0)
+    # Audit log carries the before-and-after pair
+    assert len(log) == 1
+    assert log.iloc[0]["price_real_orig"] == pytest.approx(100.0)
+    assert log.iloc[0]["price_real_replaced"] == pytest.approx(200.0)
+
+
+def test_replace_spikes_flags_and_replaces_a_high_outlier() -> None:
+    df = _make_clean_series(price_real=200.0)
+    df.loc[15, "price_real"] = 400.0  # 2x the median, ratio = 2.0
+    df.loc[15, "price_nominal"] = 400.0
+
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+
+    spike_rows = cleaned.loc[cleaned["spike_replaced"]]
+    assert len(spike_rows) == 1
+    assert spike_rows.iloc[0]["direction"] == "high"
+    assert spike_rows.iloc[0]["price_real"] == pytest.approx(200.0)
+
+
+def test_replace_spikes_keeps_nominal_in_sync_after_replacement() -> None:
+    """Cleaned nominal must equal cleaned_real * (cpi_at_obs / cpi_base).
+    Without this, the nominal-line overlays in the chart pages would
+    disagree with the cleaned real line at spike weeks."""
+    df = _make_clean_series(price_real=200.0)
+    # Use a CPI value that makes the ratio non-trivial: cpi_at_obs=180
+    # means nominal = real * (180 / 324) ≈ real * 0.5556.
+    df.loc[15, "cpi_at_obs"] = 180.0
+    df.loc[15, "price_real"] = 100.0
+    df.loc[15, "price_nominal"] = 100.0 * (180.0 / 324.0)
+
+    cleaned, _ = replace_spikes(df, cpi_base=324.0)
+
+    row = cleaned.iloc[15]
+    assert row["spike_replaced"]
+    expected_nom = row["price_real"] * (row["cpi_at_obs"] / 324.0)
+    assert row["price_nominal"] == pytest.approx(expected_nom)
+
+
+def test_replace_spikes_does_not_touch_legitimate_values() -> None:
+    """A flat 200.0 series with no injected outliers should produce zero
+    replacements and an empty log."""
+    df = _make_clean_series(price_real=200.0)
+
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+
+    assert log.empty
+    assert not cleaned["spike_replaced"].any()
+    # And the values are untouched
+    pd.testing.assert_series_equal(
+        cleaned["price_real"].reset_index(drop=True),
+        df["price_real"].reset_index(drop=True),
+        check_names=False,
+    )
+
+
+def test_replace_spikes_respects_min_abs_floor() -> None:
+    """A modest deviation that fails the ratio test but does NOT exceed
+    the absolute-deviation floor should pass through unflagged.
+
+    With a baseline of $200 and ratio_lo=0.60, a value of $100 has
+    ratio 0.50 (would fail) AND |dev|=$100 (clears the $50 floor) → flag.
+    But a baseline of $80 with the same ratio gives a value of $40,
+    |dev|=$40 (below the $50 floor) → must not flag.
+    """
+    df = _make_clean_series(price_real=80.0)
+    df.loc[15, "price_real"] = 40.0  # ratio 0.50, |dev| = $40 < $50 floor
+    df.loc[15, "price_nominal"] = 40.0
+
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+    assert log.empty
+    assert not cleaned["spike_replaced"].any()
+
+
+def test_replace_spikes_handles_each_bin_independently() -> None:
+    """The rolling median is computed per (sex, weight_class), so a
+    spike in one bin must not pull the median for an adjacent bin."""
+    df_a = _make_clean_series(sex="Heifers", weight_class="600-699", price_real=200.0)
+    df_b = _make_clean_series(sex="Steers", weight_class="500-599", price_real=240.0)
+    df_b.loc[15, "price_real"] = 120.0  # Steers spike, ratio 0.50
+    df_b.loc[15, "price_nominal"] = 120.0
+    df = pd.concat([df_a, df_b], ignore_index=True)
+
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+
+    # Exactly one replacement, in the Steers bin
+    assert len(log) == 1
+    assert log.iloc[0]["sex"] == "Steers"
+    assert log.iloc[0]["weight_class"] == "500-599"
+    # Heifers bin untouched
+    heifers = cleaned.loc[cleaned["sex"] == "Heifers"]
+    assert not heifers["spike_replaced"].any()
+
+
+def test_replace_spikes_empty_dataframe_does_not_crash() -> None:
+    df = pd.DataFrame(
+        columns=[
+            "auction_date",
+            "sex",
+            "weight_class",
+            "head_count",
+            "n_pens",
+            "price_nominal",
+            "cpi_at_obs",
+            "price_real",
+            "source_eras",
+        ]
+    )
+    cleaned, log = replace_spikes(df, cpi_base=324.0)
+    assert cleaned.empty
+    assert log.empty
+
+
+def test_replace_spikes_thresholds_can_be_overridden() -> None:
+    """`CleanConfig` is a dataclass so a test (or a future PR) can tighten
+    or loosen the rule without editing the module-level default."""
+    df = _make_clean_series(price_real=200.0)
+    df.loc[15, "price_real"] = 160.0  # ratio 0.80, default rule does NOT flag
+    df.loc[15, "price_nominal"] = 160.0
+
+    # Default config: not flagged
+    _, log_default = replace_spikes(df, cpi_base=324.0)
+    assert log_default.empty
+
+    # Strict config: ratio_lo bumped to 0.85 → 0.80 now flags
+    strict = CleanConfig(ratio_lo=0.85, ratio_hi=1.0 / 0.85, min_abs_dev=20.0)
+    _, log_strict = replace_spikes(df, cpi_base=324.0, cfg=strict)
+    assert len(log_strict) == 1


### PR DESCRIPTION
Adds a downstream cleaner that aggregates per-pen Clovis observations
     to a head-count-weighted weekly series, deflates to Dec-2025 dollars,
     and applies a symmetric rolling-median ratio test to replace obvious
     data-reporting spikes. Output is a separate artifact + audit log;
     per-pen snapshot is unchanged.

     **Why now:** the article-side pipeline already uses this exact rule;
     adding it on the platform side keeps the methodology consistent across
     the article and the public site, and gives the platform an audit log
     even when there are zero anomalies in a vintage.

     **Scope:**
     - Adds `pipelines/clovis/clean.py`
     - Wires it into `pipelines/clovis/snapshot.py` (with `--skip-clean` escape hatch)
     - Adds 16 unit tests in `tests/test_clean.py`
     - Adds a Spike-screening section to `site/methodology/clovis.qmd`
     - Adds three new artifacts to `data/processed/`:
       `clovis_weekly_cleaned_latest.parquet`, the vintage-stamped twin,
       and `clovis_spike_log_<vintage>.csv`
     - Adds `clovis_weekly_cleaned_MANIFEST.json`

     **Out of scope (follow-up PR):**
     - Migrating chart pages from the per-pen union (load.py) to the
       cleaned weekly aggregate. The chart pages currently aggregate
       themselves; switching them is a separate decision once the
       cleaned artifact has run cleanly for a few vintages.

     **Verified:**
     - All 16 unit tests pass under pytest in the `lma-explorer` env.
     - Smoke-run on current era B + MARS data produces zero spike
       replacements — the empty-audit-log-as-evidence case.
     - Methodology page renders cleanly with the new freshness block.

     **Not verified by this PR:**
     - The `[20, 800]` upstream plausibility bounds in validate.py are
       unchanged. They guard against unit-swap / decimal-shift errors
       and remain the correct upstream gate.
     - The CPI-U deflation choice is unchanged. Switching to a
       producer-side deflator (PPI Farm Products) is a Phase 2 decision.