### PR TITLE
fix(clovis): bypass main ruleset via repo-admin PAT, track spike log

### DIFF
--- a/.github/workflows/clovis_refresh.yml
+++ b/.github/workflows/clovis_refresh.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Use a fine-grained PAT so the workflow's git push is attributed to
+          # the repository admin (covered by the "protect main" ruleset's
+          # bypass list) rather than github-actions[bot] (not exempted from
+          # rulesets in the GitHub UI as of 2026-05). Without this, the
+          # snapshot commit step is rejected with GH013 / repository rule
+          # violations and the new vintage never lands on main.
+          token: ${{ secrets.BYPASS_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,10 @@ PLAN_*.md
 # Quarto's `resources:` config). Never committed; regenerated on every build.
 data/processed/*.csv
 data/processed/*.xlsx
+
+# Exception: the spike-replacement audit log written by pipelines/clovis/clean.py
+# is a primary output (not a regenerated companion of a parquet). It is
+# referenced by the cleaned-weekly manifest and documents which weekly
+# observations were replaced — an empty file is itself evidence of a clean
+# vintage. Track it in version control alongside the parquet it audits.
+!data/processed/clovis_spike_log_*.csv


### PR DESCRIPTION
Failed Clovis refresh #3 on 2026-05-07 was rejected at the commit step
  with GH013 / repository rule violations. The new "protect main" ruleset
  doesn't have github-actions[bot] in the bypass list (and that actor
  isn't selectable in the Rulesets UI), so the bot's direct push to main
  is blocked.

  This PR makes two changes so next Thursday's run lands cleanly:

  1. Checkout step uses a repo-admin-scoped fine-grained PAT
     (BYPASS_PAT) — push gets attributed to the repo admin, which is on
     the ruleset's bypass list.

  2. Adds a .gitignore exception for the spike-replacement audit log so
     it's actually tracked. (It was being written on the runner but
     ignored by the existing data/processed/*.csv rule.)

  After merge, plan to manually trigger the Clovis workflow via
  workflow_dispatch to backfill the 2026-05-07 vintage.