### PR TITLE
feat(site): add prominent legend-interaction hint above seasonality a…

### DIFF
--- a/site/seasonality.qmd
+++ b/site/seasonality.qmd
@@ -185,6 +185,10 @@ else:
 
 Each line is the average price for a weight class at each week of the calendar year, averaged across every year in the selected window. The top panel shows Steers; the bottom shows Heifers. Two button rows above the panels let the reader pick the **mode** (Nominal or Real Dec-2025 dollars) and the **year window** (All, Last 5 years, Last 3 years, or the latest calendar year); each row keeps its own highlight, so the chart at any moment reflects the combination of both selections. Hover any point to see the exact value and the number of observations behind it.
 
+::: {.callout-tip appearance="simple"}
+**To filter weight classes:** click any weight bin in the legend above the chart to hide that line; click again to show it. **Double-click one weight bin to view it alone**, and double-click any visible bin to restore all lines.
+:::
+
 ```{python}
 #| echo: false
 #| fig-alt: "Weekly seasonality chart for the Clovis, NM feeder-cattle auction. Two stacked panels (Steers above, Heifers below) overlay every weight bin (300-399 through 800-899 lb) on a 1-52 week-of-year x-axis. Each line traces the average $/cwt for one weight bin across the calendar year, with the lines for the lighter weight classes generally sitting higher than the heavier ones. The shape of each line shows the intra-year price pattern (typical seasonal peaks around late spring and late fall). Two button rows above the chart toggle year window (All, Last 5 yrs, Last 3 yrs, Latest) and currency mode (Nominal vs Real $)."

--- a/site/weekly-trends.qmd
+++ b/site/weekly-trends.qmd
@@ -181,6 +181,10 @@ else:
 
 Each line is the average price for one weight class at each auction week from October 2017 to the most recent published report. The top panel shows Steers; the bottom shows Heifers. Multiple lots within a single (week, class, weight bin) are simple-averaged so each line has one point per week. Hover any point to see the exact value and the count of lots behind it.
 
+::: {.callout-tip appearance="simple"}
+**To filter weight classes:** click any weight bin in the legend above the chart to hide that line; click again to show it. **Double-click one weight bin to view it alone**, and double-click any visible bin to restore all lines.
+:::
+
 ```{python}
 #| echo: false
 #| fig-alt: "Weekly-trends chart for the Clovis, NM feeder-cattle auction. Two stacked panels (Steers above, Heifers below) plot $/cwt against an auction-date timeline running from October 2017 to the most recent published report. Each line traces one weight bin (300-399 through 800-899 lb) at weekly resolution; gaps in the line indicate weeks where no observations were published. Two button rows above the chart toggle year window and currency mode."


### PR DESCRIPTION
…nd weekly-trends charts

A reviewer noted that producers don't realize Plotly legend items are clickable. Audit found the issue is asymmetric: seasonality.qmd had the hint buried in long prose preamble paragraphs (lines 13 and 18 of the existing 60-second guide); weekly-trends.qmd had no hint at all.

Adds an identical short callout-tip block immediately above each chart, between the prose intro and the python rendering chunk:

  'To filter weight classes: click any weight bin in the legend above
   the chart to hide that line; click again to show it. Double-click
   one weight bin to view it alone, and double-click any visible bin
   to restore all lines.'

This is a low-cost discoverability fix only. The deeper refactor Tronstad proposed — explicit weight checkboxes plus cross-sex comparison capability on a unified chart — is queued as a Tier 2 item behind the drought-destocking tool, per the user's 2026-05-09 prioritization (memory: project_chart_ux_tronstad_feedback.md).