### PR TITLE
feat(site): add Tools dropdown to navbar for producer calculators

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -63,6 +63,12 @@ website:
         href: lrp.qmd
       - text: "LRP backtest"
         href: lrp-backtest.qmd
+      - text: "Tools"
+        menu:
+          - text: "Slide-contract calculator"
+            href: tools/slide-calculator.qmd
+          - text: "Marketing-channel comparator"
+            href: tools/channel-comparator.qmd
       - text: "Methodology"
         href: methodology/index.qmd
       - text: "Glossary"


### PR DESCRIPTION
The two Tier 1 calculators shipped on 2026-05-09 (slide-contract calculator and marketing-channel comparator) were not wired into the navbar — only reachable via direct URL. This PR adds a 'Tools' menu entry between 'LRP backtest' and 'Methodology' with both calculators listed as sub-items.

Dropdown was preferred over adding the two pages directly to the navbar (which was already at 12 entries) and over creating a dedicated Tools index page (extra click for users with no benefit at two-tool scale). Pattern scales to additional tools by adding sub-items.

Tools index page deferred until 3+ tools warrant the IA investment.