### PR TITLE
docs(tools): correct Rasby & Mark title and Parish et al. authorship

### DIFF
--- a/site/tools/channel-comparator.qmd
+++ b/site/tools/channel-comparator.qmd
@@ -853,7 +853,7 @@ Griffith, A. P. (2015). *Marketing feeder cattle via video auction* (Publication
 
 Iowa State University Extension and Outreach. (2025). *Livestock enterprise budgets for Iowa* (Ag Decision Maker File B1-21; FM 1815, Revised June 2025). [https://www.extension.iastate.edu/agdm/livestock/html/b1-21.html](https://www.extension.iastate.edu/agdm/livestock/html/b1-21.html)
 
-Parish, J. A., Rhinehart, J. D., & Anderson, J. D. (2021). *Marketing feeder calves* (Publication 2552). Mississippi State University Extension Service. [https://extension.msstate.edu/sites/default/files/publications/P2552_web.pdf](https://extension.msstate.edu/sites/default/files/publications/P2552_web.pdf)
+Parish, J. A., Rhinehart, J. D., Anderson, J. D., & Karisch, B. (2021). *Marketing feeder calves* (Publication 2552). Mississippi State University Extension Service. [https://extension.msstate.edu/sites/default/files/publications/P2552_web.pdf](https://extension.msstate.edu/sites/default/files/publications/P2552_web.pdf)
 
 Sartwelle, J. D., III, Davis, E. E., Mintert, J., & Borchardt, R. (2000). *Beef cattle marketing alliances* (Risk Management Publication L-5356/RM1-9.0). Texas Agricultural Extension Service, The Texas A&M University System.
 

--- a/site/tools/slide-calculator.qmd
+++ b/site/tools/slide-calculator.qmd
@@ -7,7 +7,7 @@ toc-depth: 2
 
 ## What this tool does
 
-When feeder cattle are sold for forward delivery — through video auctions, internet auctions, or private treaty — the weight at delivery almost always differs from the contracted weight. A **price slide** is the mechanical adjustment in $/cwt that compensates. This calculator implements the standard slide formula documented in Rasby and Mark (2011), *Feeder cattle price slides* (NebGuide G2088, University of Nebraska–Lincoln Extension), and lets a producer plug in their own contract terms to see the per-head and total payment.
+When feeder cattle are sold for forward delivery — through video auctions, internet auctions, or private treaty — the weight at delivery almost always differs from the contracted weight. A **price slide** is the mechanical adjustment in $/cwt that compensates. This calculator implements the standard slide formula documented in Rasby and Mark (2011), *Pricing feeder cattle: Price slides* (NebGuide G2088, University of Nebraska–Lincoln Extension), and lets a producer plug in their own contract terms to see the per-head and total payment.
 
 The math is linear and reproducible in a spreadsheet. For offline use, an [Excel companion](downloads/slide-contract-calculator.xlsx) is available below — same math, same defaults, same outputs.
 
@@ -608,7 +608,7 @@ A spreadsheet version of this calculator is available for offline use: [slide-co
 
 ## Methodology and limits
 
-The slide formula implemented here is standard in U.S. feeder-cattle forward-contract practice and is documented in published Extension sources, including Rasby and Mark (2011), *Feeder cattle price slides* (NebGuide G2088, University of Nebraska–Lincoln Extension). The formula's logic, condensed:
+The slide formula implemented here is standard in U.S. feeder-cattle forward-contract practice and is documented in published Extension sources, including Rasby and Mark (2011), *Pricing feeder cattle: Price slides* (NebGuide G2088, University of Nebraska–Lincoln Extension). The formula's logic, condensed:
 
 1. **Pay weight** = delivered weight × (1 − pencil shrink). Shrink is a pre-agreed deduction from delivered weight to approximate hauled-in weight.
 2. **Window check.** If pay weight is within the agreed window around the base weight (typically ±10 lb), no slide adjustment applies.
@@ -637,4 +637,4 @@ Sall, I., & Tronstad, R. (2026). *Slide-contract calculator for feeder cattle* [
 
 ## References
 
-Rasby, R. J., & Mark, D. R. (2011). *Feeder cattle price slides* (NebGuide G2088). University of Nebraska–Lincoln Extension. [https://extensionpubs.unl.edu/publication/g2088/2011/html/view](https://extensionpubs.unl.edu/publication/g2088/2011/html/view)
+Rasby, R. J., & Mark, D. R. (2011). *Pricing feeder cattle: Price slides* (NebGuide G2088). University of Nebraska–Lincoln Extension. [https://extensionpubs.unl.edu/publication/g2088/2011/html/view](https://extensionpubs.unl.edu/publication/g2088/2011/html/view)


### PR DESCRIPTION
Two citation drift items surfaced during cross-check against the updated `Article_1_Draft_Marketing_Alternatives_AZ.docx` reference list (refreshed 2026-05-12).

## Rasby & Mark (2011) — title correction

The published title of NebGuide G2088 is *Pricing feeder cattle: Price slides*, not *Feeder cattle price slides* as previously cited. URL `https://extensionpubs.unl.edu/publication/g2088/2011/html/view` confirms the correct title in the page header.

Fixed three instances in `site/tools/slide-calculator.qmd`: page intro (line 10), methodology section (line 611), and references block (line 640).

## Parish et al. (2021) — fourth author added

The publication is authored by Parish, Rhinehart, Anderson, **and Karisch**. The platform's citation omitted Karisch, B. Fixed one instance in the references block of `site/tools/channel-comparator.qmd` (line 856).

The two in-text mentions of "Parish et al. (2021)" in the same file are correct as-is ("et al." abbreviates the author list and is conventional once a full citation has been established in the references block).

## Notes

The Bucket C citation-verification pass on 2026-05-10 missed both of these because it confirmed the publications exist (via WebSearch) but didn't reconcile against the article's own reference list. Future citation audits should add a step: "does the platform's citation match the canonical bibliographic entry in the companion article's references?"

URLs unchanged. No code-behavior changes. Documentation-only.