### PR TITLE
feat(tools): make channel-comparator override grid always-visible

### DIFF
--- a/site/tools/channel-comparator.qmd
+++ b/site/tools/channel-comparator.qmd
@@ -51,12 +51,12 @@ This tool compares the **cost structure** of the five cash channels under a sing
     </div>
   </fieldset>
 
-  <details class="overrides">
-    <summary><strong>Adjust default cost assumptions per channel</strong> (click to expand)</summary>
+  <section class="overrides">
+    <h3 class="overrides-heading">Default cost assumptions per channel</h3>
     <p class="overrides-note">All default values come from regional Extension literature and trade-press surveys. Edit any cell to match your local market; the comparator updates live.</p>
     <div id="overrides-grid"></div>
     <button type="button" id="resetOverrides">Reset all channel defaults</button>
-  </details>
+  </section>
 
   <div id="input-error" class="input-error" style="display:none;"></div>
 </form>
@@ -140,16 +140,17 @@ This tool compares the **cost structure** of the five cash channels under a sing
     color: #800;
     margin-top: 0.5em;
   }
-  details.overrides {
+  section.overrides {
     margin-bottom: 1em;
     padding: 0.5em 1em;
     background: #FAFAFA;
     border: 1px solid #DDD;
     border-radius: 4px;
   }
-  details.overrides summary {
-    cursor: pointer;
-    padding: 0.25em 0;
+  .overrides-heading {
+    font-size: 1.05em;
+    margin: 0.4em 0 0.6em 0;
+    color: #2F6FB2;
   }
   .overrides-note {
     font-size: 0.9em;
@@ -335,7 +336,7 @@ This tool compares the **cost structure** of the five cash channels under a sing
       border: 1px solid #000;
     }
     .results-actions { display: none; }
-    details.overrides { display: none; }
+    
     #show-math[open] summary { display: none; }
   }
 </style>


### PR DESCRIPTION
Replace the expand-on-click <details>/<summary> with an always-visible <section>/<h3>. The override grid contains the 25 default cost values that drive each channel's net price; hiding them behind an expand affordance contradicted the page's own disclaimer ("Edit any cell to match your local market; the comparator updates live") because users who took the defaults at face value never saw what they were being asked to customize.

Aligned with the platform's transparency posture: the assumptions that drive the output should be visible without a click.

Three changes:
- HTML: <details> → <section>, <summary> → <h3 class="overrides-heading">. Title shortens to "Default cost assumptions per channel" (no expand affordance needed).
- On-screen CSS: rename details.overrides → section.overrides; replace the summary cursor:pointer rule with .overrides-heading typography (1.05em, blue heading color matching legend styling).
- Print stylesheet: drop the rule that hid the override grid in print. Same transparency rationale: if the values drive the on-screen output, the printed artifact a producer files with their lender or Extension agent should also show those values.

Net +1 line. No JS changes; the existing overrides-grid rendering and the reset-defaults button continue working as before. Mobile responsive behavior unchanged (overrides-grid already has overflow-x: auto for horizontal scroll on small screens).