### PR TITLE
fix(clovis/validate): exclude cleaned-weekly parquet from prior-snapshot selection

### DIFF
--- a/pipelines/clovis/validate.py
+++ b/pipelines/clovis/validate.py
@@ -19,7 +19,9 @@ does NOT commit a new snapshot.
        back than ``MAX_HISTORY_REVISION_DEPTH`` weeks triggers a failure.
 
 Reads the most recent raw JSON under data/raw/clovis/ and the most recent
-committed parquet under data/processed/clovis_weekly_*.parquet. Writes nothing.
+committed per-pen parquet matching data/processed/clovis_weekly_<YYYY-MM-DD>.parquet.
+The cleaned-weekly aggregate (clovis_weekly_cleaned_*.parquet, written by clean.py)
+shares the same prefix but is deliberately excluded — see _latest_snapshot. Writes nothing.
 
 Usage:
     python -m pipelines.clovis.validate                 # validate latest raw
@@ -36,6 +38,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -89,14 +92,31 @@ def _latest_raw() -> Path:
     return candidates[-1]
 
 
+# Strict pattern: only the per-pen vintage snapshots written by snapshot.py.
+# The naive prefix "clovis_weekly_" also matches the cleaner's output
+# (clovis_weekly_cleaned_*.parquet), which has a different schema and a
+# CPI-truncated date range — picking it as the prior snapshot makes
+# check_continuity see spurious "new" old dates and fire a false-positive
+# AssertionError (observed in production 2026-05-14 on run #6 of the
+# clovis_refresh workflow). The strict regex prevents that. Mirrors the
+# pattern in pipelines/bls/validate.py, which uses re for the same reason.
+_WEEKLY_VINTAGE_RE = re.compile(r"^clovis_weekly_\d{4}-\d{2}-\d{2}\.parquet$")
+
+
 def _latest_snapshot() -> Path | None:
-    """Newest clovis_weekly_*.parquet (excluding the release-basis file)."""
+    """Newest per-pen ``clovis_weekly_<YYYY-MM-DD>.parquet`` snapshot.
+
+    Strict regex match — deliberately excludes ``clovis_weekly_cleaned_*.parquet``
+    (the cleaner's output, same prefix but different schema and CPI-truncated
+    date range) and any other prefix or non-vintage filename. Returns ``None``
+    if no committed vintage exists yet (first run).
+    """
     if not PROCESSED_DIR.exists():
         return None
     candidates = sorted(
         p
         for p in PROCESSED_DIR.iterdir()
-        if p.name.startswith("clovis_weekly_") and p.name.endswith(".parquet")
+        if _WEEKLY_VINTAGE_RE.match(p.name)
     )
     return candidates[-1] if candidates else None
 

--- a/tests/test_clovis_validate.py
+++ b/tests/test_clovis_validate.py
@@ -1,0 +1,157 @@
+"""Tests for pipelines/clovis/validate.py's prior-snapshot file selection.
+
+Regression coverage for the production failure observed on 2026-05-14
+(clovis_refresh.yml run #6): `_latest_snapshot()` must pick the per-pen
+vintage file (``clovis_weekly_<YYYY-MM-DD>.parquet``) and NOT the cleaned-
+weekly aggregate (``clovis_weekly_cleaned_*.parquet``), even though both
+files share the ``clovis_weekly_`` prefix.
+
+The original failure mode: the loose ``startswith("clovis_weekly_")`` filter
+matched both file families. By string sort, ``clovis_weekly_cleaned_latest.parquet``
+sorts last (``'c'`` > ``'2'``), so ``candidates[-1]`` returned the cleaner's
+output. That file has a CPI-truncated date range and a different schema, which
+made ``check_continuity`` see spurious "new" old dates and raise a false-positive
+AssertionError. The fix is a strict regex matching only the per-pen vintage
+filename pattern.
+
+These tests use synthetic empty files in pytest's tmp_path (no actual parquet
+contents needed — ``_latest_snapshot()`` only inspects filenames). The module-
+level ``PROCESSED_DIR`` is monkey-patched per-test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pipelines.clovis import validate as v
+
+
+# --- regression coverage for the production failure -------------------------
+
+
+def test_latest_snapshot_picks_per_pen_not_cleaned(tmp_path, monkeypatch):
+    """The bug: cleaned-weekly files sort last and were wrongly picked.
+    The fix: strict regex matches only ``clovis_weekly_<YYYY-MM-DD>.parquet``.
+    """
+    files = [
+        "clovis_weekly_2026-04-23.parquet",
+        "clovis_weekly_2026-04-30.parquet",
+        "clovis_weekly_2026-05-08.parquet",
+        "clovis_weekly_cleaned_2026-05-08.parquet",  # WAS wrongly picked pre-fix
+        "clovis_weekly_cleaned_latest.parquet",      # WAS wrongly picked pre-fix
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+
+    result = v._latest_snapshot()
+    assert result is not None
+    assert result.name == "clovis_weekly_2026-05-08.parquet", (
+        f"Expected per-pen vintage, got {result.name!r}. "
+        "Regression: a cleaned-weekly file was probably wrongly selected."
+    )
+
+
+def test_latest_snapshot_returns_none_when_only_cleaned_files_present(
+    tmp_path, monkeypatch
+):
+    """Cleaned files alone must NOT be returned as the per-pen baseline."""
+    files = [
+        "clovis_weekly_cleaned_latest.parquet",
+        "clovis_weekly_cleaned_2026-05-08.parquet",
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    assert v._latest_snapshot() is None
+
+
+def test_latest_snapshot_ignores_unrelated_prefixes(tmp_path, monkeypatch):
+    """Other artifact filenames in data/processed/ must not be picked up.
+
+    Notably: ``clovis_slaughter_*`` (added 2026-05-14 in 4.drought-b),
+    ``clovis_latest`` (the convenience alias), ``clovis_historical_*``,
+    ``cpi_*``, ``lrp_*``, and the release-basis file.
+    """
+    files = [
+        "clovis_latest.parquet",
+        "clovis_slaughter_latest.parquet",
+        "clovis_slaughter_2026-05-21.parquet",
+        "clovis_historical_era_b_latest.parquet",
+        "clovis_release_basis_2025.parquet",
+        "cpi_latest.parquet",
+        "lrp_latest.parquet",
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    assert v._latest_snapshot() is None
+
+
+# --- basic existence and ordering coverage ---------------------------------
+
+
+def test_latest_snapshot_returns_none_when_dir_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    assert v._latest_snapshot() is None
+
+
+def test_latest_snapshot_returns_none_when_processed_dir_missing(
+    tmp_path, monkeypatch
+):
+    missing = tmp_path / "nonexistent"
+    monkeypatch.setattr(v, "PROCESSED_DIR", missing)
+    assert v._latest_snapshot() is None
+
+
+def test_latest_snapshot_picks_most_recent_by_date(tmp_path, monkeypatch):
+    """Among multiple per-pen vintages, the most recent date wins (lex sort
+    on YYYY-MM-DD == chronological sort).
+    """
+    files = [
+        "clovis_weekly_2026-04-30.parquet",
+        "clovis_weekly_2026-05-08.parquet",
+        "clovis_weekly_2026-04-23.parquet",  # creation order irrelevant
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    result = v._latest_snapshot()
+    assert result.name == "clovis_weekly_2026-05-08.parquet"
+
+
+def test_latest_snapshot_excludes_non_parquet_extensions(tmp_path, monkeypatch):
+    """Files matching the date pattern but with non-parquet extensions are
+    excluded by the regex's literal ``\\.parquet$`` anchor.
+    """
+    files = [
+        "clovis_weekly_2026-05-08.parquet",
+        "clovis_weekly_2026-05-15.json",  # not parquet
+        "clovis_weekly_2026-05-15.csv",   # not parquet
+        "clovis_weekly_2026-05-15.parquet.bak",  # not exactly .parquet
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    result = v._latest_snapshot()
+    assert result.name == "clovis_weekly_2026-05-08.parquet"
+
+
+def test_latest_snapshot_excludes_malformed_vintage_strings(
+    tmp_path, monkeypatch
+):
+    """The vintage portion must be a strict YYYY-MM-DD; partial dates,
+    extra suffixes, or non-numeric components do not match.
+    """
+    files = [
+        "clovis_weekly_2026-05-08.parquet",           # valid; must win
+        "clovis_weekly_2026-05.parquet",              # missing day
+        "clovis_weekly_2026-05-08-extra.parquet",     # extra suffix
+        "clovis_weekly_latest.parquet",               # not a date
+        "clovis_weekly_release_basis_2025.parquet",   # not a date
+    ]
+    for fname in files:
+        (tmp_path / fname).write_bytes(b"")
+    monkeypatch.setattr(v, "PROCESSED_DIR", tmp_path)
+    result = v._latest_snapshot()
+    assert result.name == "clovis_weekly_2026-05-08.parquet"

--- a/tests/test_clovis_validate.py
+++ b/tests/test_clovis_validate.py
@@ -21,8 +21,6 @@ level ``PROCESSED_DIR`` is monkey-patched per-test.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from pipelines.clovis import validate as v
 
 


### PR DESCRIPTION
## Problem

`clovis_refresh.yml` run #6 (2026-05-14) failed in the **Validate** step with:

> `AssertionError: 5 new auction date(s) older than 2w before prior snapshot's newest date (2026-03-25); deep-history revision suspected.`

## Root cause

`pipelines/clovis/validate.py::_latest_snapshot()` used a loose prefix filter:

```python
if p.name.startswith("clovis_weekly_")
```

That prefix matches **both** file families produced by the pipeline:
- `clovis_weekly_<YYYY-MM-DD>.parquet` — the per-pen vintage (the intended baseline)
- `clovis_weekly_cleaned_*.parquet` — the cleaner's output (different schema, CPI-truncated date range)

By string sort, `clovis_weekly_cleaned_latest.parquet` sorts last (`'c'` > `'2'`), so `candidates[-1]` returned the cleaned file. Its CPI-truncated newest date (2026-03-25) made `check_continuity` see the per-pen vintage's pre-2026-03-25 dates as "new" old dates and raise.

The bug was latent until the cleaned files were first committed (with the 2026-05-08 refresh, run #5). Run #6 is the first to see them post-commit.

## Fix

Strict regex matching only `clovis_weekly_<YYYY-MM-DD>.parquet`. Mirrors the existing pattern in `pipelines/bls/validate.py`.

## Tests

New `tests/test_clovis_validate.py` (8 tests):
- regression: cleaned files not picked when per-pen vintage present
- only-cleaned-files dir returns `None`
- unrelated prefixes ignored (`clovis_slaughter_*`, `cpi_*`, `lrp_*`, etc.)
- empty dir, missing dir
- most-recent-by-date ordering
- non-parquet extensions excluded
- malformed vintage strings excluded

## Verification

- 8/8 new tests pass
- Full suite: 102 passed, 3 skipped — no regressions
- `_latest_snapshot()` against real `data/processed/` now returns `clovis_weekly_2026-05-08.parquet` (the correct per-pen vintage)
- `python3 -m pipelines.clovis.validate` runs clean end-to-end against the 2026-04-23 raw JSON